### PR TITLE
delete second copy of githubv4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/cli/go-gh v0.1.2
 	github.com/cli/shurcooL-graphql v0.0.2
-	github.com/shurcool/githubv4 v0.0.0-20221021030919-a134b1472cc7
+	github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00
 )
 
 require (
@@ -23,7 +23,6 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/muesli/termenv v0.12.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00 // indirect
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect
 	github.com/stretchr/testify v1.7.5 // indirect
 	github.com/thlib/go-timezone-local v0.0.0-20210907160436-ef149e42d28e // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,6 @@ github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00 h1:fiFvD4lT0aWju
 github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 h1:B1PEwpArrNp4dkQrfxh/abbBAOZBVp0ds+fBEOUOqOc=
 github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
-github.com/shurcool/githubv4 v0.0.0-20221021030919-a134b1472cc7 h1:muP/A3cU3EcMbIJ4Pfwpy/++m4QPjuspWmndsfoh5qU=
-github.com/shurcool/githubv4 v0.0.0-20221021030919-a134b1472cc7/go.mod h1:Rx+WSUainkHWg5qIfDBVuYoAU6fDL4/+A4/r1jryErg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/sandbox/date_field_mutation.go
+++ b/sandbox/date_field_mutation.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/cli/go-gh"
 	graphql "github.com/cli/shurcooL-graphql"
-	"github.com/shurcool/githubv4"
+	"github.com/shurcooL/githubv4"
 	"log"
 )
 

--- a/types.go
+++ b/types.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/shurcool/githubv4"
+import "github.com/shurcooL/githubv4"
 
 type Project struct {
 	Title string


### PR DESCRIPTION
There were two required modules providing the same package `githubv4`.
Delete second one whose module path doesn't match the [canonical one](https://github.com/shurcooL/githubv4/blob/095e54f8d08f48f2d886d983114bf5fec9c16ad3/go.mod#L1).