### PR TITLE
feat: -fieldオプションでカスタムフィールド値をCLIから指定可能にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`gh-ap` is a GitHub CLI extension that adds Issues or Pull Requests to GitHub Projects (V2) with interactive custom field updates. It uses `gh` CLI as a host and communicates with GitHub via GraphQL API.
+
+## Build & Run
+
+```bash
+# Build
+go build -o gh-ap
+
+# Run (must be in a git repo with gh CLI authenticated)
+gh ap
+gh ap -issue 123
+gh ap -pr 456
+
+# With field values
+gh ap -issue 123 -field "Status=Done" -field "Priority=High"
+
+# Run tests
+go test ./...
+```
+
+## Architecture
+
+All code is in `package main` with no subdirectories (aside from `sandbox/` which contains standalone GraphQL exploration scripts).
+
+| File | Role |
+|------|------|
+| `main.go` | Entry point, CLI flag parsing, orchestrates the interactive flow |
+| `cli.go` | Wraps `gh` CLI commands (repo view, pr view, issue view/list) via `gh.Exec` |
+| `query.go` | GraphQL queries: user/org projects, project fields, field types |
+| `mutation.go` | GraphQL mutations: add item to project, update field values (text/date/number/select/iteration) |
+| `survey.go` | Interactive prompts using `survey/v2` for project/content/field selection |
+| `fields.go` | Merges field type info with field options (single-select, iteration) |
+| `types.go` | Shared struct definitions (Project, Content, Option, ProjectField, Repository) |
+
+## Key Libraries
+
+- `github.com/cli/go-gh` — gh CLI host library (REST client, GQL client, exec)
+- `github.com/cli/shurcooL-graphql` — GraphQL query/mutation construction via Go struct tags
+- `github.com/AlecAivazis/survey/v2` — interactive terminal prompts
+- `github.com/shurcooL/githubv4` — GitHub v4 API types (used for `githubv4.Date`)
+
+## Flow
+
+1. Fetch user projects + org projects (if repo is in an org)
+2. User selects a project interactively
+3. Fetch project fields and their types/options
+4. User selects content type (Current PR / PR / Issue) or uses `-issue`/`-pr` flags
+5. Add the content to the project via `addProjectV2ItemById` mutation
+6. For each custom field, use CLI `-field` value if provided, otherwise prompt user for input, and update via `updateProjectV2ItemFieldValue` mutation
+
+## Release
+
+Tags matching `v*` trigger `.github/workflows/release.yml` which uses `cli/gh-extension-precompile` to build and publish.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ gh ap
 
 ```bash
 gh ap --help
+  -field value
+        Field value in 'FieldName=Value' format (can be specified multiple times)
   -issue int
         Issue Number
   -pr int
@@ -29,6 +31,16 @@ gh ap -issue ${issueNumber}
 ```bash
 gh ap -pr ${pullRequestNumber}
 ```
+
+- Specified Field Values(Optional)
+
+Set custom field values directly without interactive prompts. Can be specified multiple times for multiple fields.
+
+```bash
+gh ap -issue 123 -field "Status=Done" -field "Priority=High"
+```
+
+Supported field types: Text, Date(`YYYY-MM-DD`), Number, Single Select, Iteration
 
 ## Demo
 

--- a/main.go
+++ b/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"github.com/cli/go-gh"
 	"github.com/cli/go-gh/pkg/api"
 	"log"
 	"strconv"
+	"strings"
 )
 
 func getProjects(gqlclient api.GQLClient) []Project {
@@ -55,13 +57,47 @@ func getProjects(gqlclient api.GQLClient) []Project {
 	return projects
 }
 
+type fieldFlags []string
+
+func (f *fieldFlags) String() string {
+	return strings.Join(*f, ", ")
+}
+
+func (f *fieldFlags) Set(value string) error {
+	if !strings.Contains(value, "=") {
+		return fmt.Errorf("field format must be 'FieldName=Value'")
+	}
+	*f = append(*f, value)
+	return nil
+}
+
+func parseFieldFlags(flags fieldFlags) map[string]string {
+	fieldValues := make(map[string]string)
+	for _, f := range flags {
+		parts := strings.SplitN(f, "=", 2)
+		fieldValues[parts[0]] = parts[1]
+	}
+	return fieldValues
+}
+
+func findOptionByName(options []Option, name string) (Option, bool) {
+	for _, opt := range options {
+		if opt.Name == name {
+			return opt, true
+		}
+	}
+	return Option{}, false
+}
+
 func main() {
 	var options struct {
 		issueNo int
 		prNo    int
+		fields  fieldFlags
 	}
 	flag.IntVar(&options.issueNo, "issue", 0, "Issue Number")
 	flag.IntVar(&options.prNo, "pr", 0, "PullRequest Number")
+	flag.Var(&options.fields, "field", "Field value in 'FieldName=Value' format (can be specified multiple times)")
 	flag.Parse()
 
 	gqlclient, err := gh.GQLClient(nil)
@@ -96,34 +132,66 @@ func main() {
 	}
 	itemId = addProject(gqlclient, projectId, content.Id)
 
+	fieldValues := parseFieldFlags(options.fields)
+
 	for _, field := range fields {
+		cliValue, hasCLIValue := fieldValues[field.Name]
+
 		if field.DataType == "TEXT" {
-			input := askTextFieldValue(field.Name)
+			var input string
+			if hasCLIValue {
+				input = cliValue
+			} else {
+				input = askTextFieldValue(field.Name)
+			}
 			if input != "" {
 				updateTextProjectField(gqlclient, projectId, itemId, field.Id, input)
 			}
 		}
 		if field.DataType == "DATE" {
-			dateInput := askDateFieldValue(field.Name)
-
+			var dateInput string
+			if hasCLIValue {
+				dateInput = cliValue
+			} else {
+				dateInput = askDateFieldValue(field.Name)
+			}
 			if dateInput != "" {
 				updateDateProjectField(gqlclient, projectId, itemId, field.Id, dateInput)
 			}
 		}
 		if field.DataType == "NUMBER" {
-			f := askNumberFieldValue(field.Name)
-			updateNumberProjectField(gqlclient, projectId, itemId, field.Id, f)
+			if hasCLIValue {
+				f, err := strconv.ParseFloat(cliValue, 64)
+				if err != nil {
+					log.Fatalf("Invalid number value for field %s: %s", field.Name, cliValue)
+				}
+				updateNumberProjectField(gqlclient, projectId, itemId, field.Id, f)
+			} else {
+				f := askNumberFieldValue(field.Name)
+				updateNumberProjectField(gqlclient, projectId, itemId, field.Id, f)
+			}
 		}
 		if field.DataType == "SINGLE_SELECT" || field.DataType == "ITERATION" {
-			selected := askOneSelectFieldValue(field.Name, field.Options)
-
-			if selected == "Skip" {
-				continue
-			}
-			if field.DataType == "ITERATION" {
-				updateIterationProjectField(gqlclient, projectId, itemId, field.Id, selected)
+			if hasCLIValue {
+				opt, found := findOptionByName(field.Options, cliValue)
+				if !found {
+					log.Fatalf("Option '%s' not found for field '%s'", cliValue, field.Name)
+				}
+				if field.DataType == "ITERATION" {
+					updateIterationProjectField(gqlclient, projectId, itemId, field.Id, opt.Id)
+				} else {
+					updateSingleSelectProjectField(gqlclient, projectId, itemId, field.Id, opt.Id)
+				}
 			} else {
-				updateSingleSelectProjectField(gqlclient, projectId, itemId, field.Id, selected)
+				selected := askOneSelectFieldValue(field.Name, field.Options)
+				if selected == "Skip" {
+					continue
+				}
+				if field.DataType == "ITERATION" {
+					updateIterationProjectField(gqlclient, projectId, itemId, field.Id, selected)
+				} else {
+					updateSingleSelectProjectField(gqlclient, projectId, itemId, field.Id, selected)
+				}
 			}
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseFieldFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		flags    fieldFlags
+		expected map[string]string
+	}{
+		{
+			name:     "空のフラグ",
+			flags:    fieldFlags{},
+			expected: map[string]string{},
+		},
+		{
+			name:  "単一フィールド",
+			flags: fieldFlags{"Status=Done"},
+			expected: map[string]string{
+				"Status": "Done",
+			},
+		},
+		{
+			name:  "複数フィールド",
+			flags: fieldFlags{"Status=Done", "Priority=High"},
+			expected: map[string]string{
+				"Status":   "Done",
+				"Priority": "High",
+			},
+		},
+		{
+			name:  "値にイコールを含む",
+			flags: fieldFlags{"Note=a=b=c"},
+			expected: map[string]string{
+				"Note": "a=b=c",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseFieldFlags(tt.flags)
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d fields, got %d", len(tt.expected), len(result))
+			}
+			for k, v := range tt.expected {
+				if result[k] != v {
+					t.Errorf("expected %s=%s, got %s=%s", k, v, k, result[k])
+				}
+			}
+		})
+	}
+}
+
+func TestFieldFlagsSet(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{
+			name:    "正しいフォーマット",
+			value:   "Status=Done",
+			wantErr: false,
+		},
+		{
+			name:    "イコールなし",
+			value:   "InvalidFormat",
+			wantErr: true,
+		},
+		{
+			name:    "空の値",
+			value:   "Key=",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var f fieldFlags
+			err := f.Set(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Set(%s) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+			if err == nil && len(f) != 1 {
+				t.Errorf("expected 1 flag, got %d", len(f))
+			}
+		})
+	}
+}
+
+func TestFindOptionByName(t *testing.T) {
+	options := []Option{
+		{Id: "id1", Name: "Done"},
+		{Id: "id2", Name: "In Progress"},
+		{Id: "id3", Name: "Todo"},
+	}
+
+	tests := []struct {
+		name      string
+		search    string
+		wantFound bool
+		wantId    string
+	}{
+		{
+			name:      "存在するオプション",
+			search:    "Done",
+			wantFound: true,
+			wantId:    "id1",
+		},
+		{
+			name:      "存在しないオプション",
+			search:    "NotExist",
+			wantFound: false,
+		},
+		{
+			name:      "スペースを含むオプション",
+			search:    "In Progress",
+			wantFound: true,
+			wantId:    "id2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt, found := findOptionByName(options, tt.search)
+			if found != tt.wantFound {
+				t.Errorf("findOptionByName(%s) found = %v, want %v", tt.search, found, tt.wantFound)
+			}
+			if found && opt.Id != tt.wantId {
+				t.Errorf("findOptionByName(%s) Id = %s, want %s", tt.search, opt.Id, tt.wantId)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

`-field "FieldName=Value"` オプションを追加し、カスタムフィールドの値をCLIから直接指定できるようにした。

## Why

- CI/スクリプトなど非インタラクティブな環境からフィールド値を設定したいユースケースに対応するため
- PR #17 (`feat/cli-options-for-fields`) でブランチ名としては意図されていたが、実装コードがマージに含まれていなかったため再実装

## How

- `main.go` に `fieldFlags` カスタムフラグ型を追加し、`-field` オプションを複数回指定可能に
- フィールド更新ループで `-field` の値が指定されている場合はインタラクティブプロンプトをスキップして値を直接使用
- TEXT / DATE / NUMBER / SINGLE_SELECT / ITERATION の全フィールドタイプに対応

## 確認観点

- [x] `go build` が成功すること
- [x] `go test ./...` が全て通ること
- [x] `./gh-ap --help` で `-field` オプションが表示されること
- [x] `parseFieldFlags` のテスト（空・単一・複数・値にイコール含む）
- [x] `fieldFlags.Set` のバリデーションテスト（正常・イコールなし・空値）
- [x] `findOptionByName` のテスト（存在する/しないオプション）