### PR TITLE
ci: release workflowのアクションをアップデート

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
-      - uses: cli/gh-extension-precompile@v1
+      - uses: actions/checkout@v4.2.2
+      - uses: cli/gh-extension-precompile@v2.1.0


### PR DESCRIPTION
## 概要

release workflowで使用しているアクションをアップデート

## Why

`cli/gh-extension-precompile@v1` が古いGoツールチェインを使用しており、`go.mod` の `go 1.23.0` 形式（3パートバージョン）を解析できず、リリースワークフローが失敗していた

## How

- `cli/gh-extension-precompile` を `v1` → `v2.1.0` にアップデート
- `actions/checkout` を `v3` → `v4.2.2` にアップデート
- `timeout-minutes: 30` を追加

## 確認観点

- [x] ローカルでのビルド・テストが通ること (`go build` / `go test ./...`)
- [x] release.ymlの構文が正しいこと
- [x] アクションのバージョンがパッチバージョンまで固定されていること
- [x] timeout-minutesが設定されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)