### PR TITLE
ci: release workflowでgo.modからGoバージョンを読み取るよう設定

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,3 +13,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: cli/gh-extension-precompile@v2.1.0
+        with:
+          go_version_file: go.mod


### PR DESCRIPTION
## 概要

release workflowの`gh-extension-precompile`に`go_version_file: go.mod`を追加

## Why

`cli/gh-extension-precompile`は`go_version`/`go_version_file`未指定時、デフォルトで**Go 1.18**を使用する。Go 1.18は`go.mod`の`go 1.23.0`（3パートバージョン）形式を解析できず、リリースワークフローが失敗していた。

## How

`go_version_file: go.mod`を指定し、go.modに記載されたGoバージョンでセットアップされるようにした。test.ymlの`setup-go`と同様のアプローチ。

## 確認観点

- [x] action.ymlで`go_version_file`入力がサポートされていることを確認
- [x] `go_version_file`指定時は`actions/setup-go`にそのまま渡され、go.modからバージョンを読み取る動作を確認
- [x] release.ymlの構文が正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)