### PR TITLE
-projectと-project-idオプションでプロジェクトをCLIから指定可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ gh ap --help
         Issue Number
   -pr int
         PullRequest Number
+  -project string
+        Project Name
+  -project-id int
+        Project Number (the number shown in the project URL)
 ```
 
 - Specified Issue Number(Optional)
@@ -31,6 +35,20 @@ gh ap -issue ${issueNumber}
 ```bash
 gh ap -pr ${pullRequestNumber}
 ```
+
+- Specified Project Name(Optional)
+
+```bash
+gh ap -project "My Project"
+```
+
+- Specified Project Number(Optional)
+
+```bash
+gh ap -project-id 1
+```
+
+Note: `-project` and `-project-id` cannot be used together.
 
 - Specified Field Values(Optional)
 

--- a/main.go
+++ b/main.go
@@ -89,24 +89,82 @@ func findOptionByName(options []Option, name string) (Option, bool) {
 	return Option{}, false
 }
 
+func resolveProjectIdByNumber(gqlclient api.GQLClient, number int) string {
+	restClient, err := gh.RESTClient(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	response := struct{ Login string }{}
+	err = restClient.Get("user", &response)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Try user project first
+	if id, found := queryUserProjectByNumber(gqlclient, response.Login, number); found {
+		return id
+	}
+
+	// Try organization project
+	repository := ghRepository()
+	if repository.IsInOrganization {
+		if id, found := queryOrganizationProjectByNumber(gqlclient, repository.Owner.Login, number); found {
+			return id
+		}
+	}
+
+	log.Fatalf("Project #%d not found", number)
+	return ""
+}
+
+func findProjectByName(projects []Project, name string) (string, bool) {
+	for _, p := range projects {
+		if p.Title == name {
+			return p.Id, true
+		}
+	}
+	return "", false
+}
+
 func main() {
 	var options struct {
-		issueNo int
-		prNo    int
-		fields  fieldFlags
+		issueNo       int
+		prNo          int
+		projectName   string
+		projectNumber int
+		fields        fieldFlags
 	}
 	flag.IntVar(&options.issueNo, "issue", 0, "Issue Number")
 	flag.IntVar(&options.prNo, "pr", 0, "PullRequest Number")
+	flag.StringVar(&options.projectName, "project", "", "Project Name")
+	flag.IntVar(&options.projectNumber, "project-id", 0, "Project Number (the number shown in the project URL)")
 	flag.Var(&options.fields, "field", "Field value in 'FieldName=Value' format (can be specified multiple times)")
 	flag.Parse()
+
+	if options.projectName != "" && options.projectNumber != 0 {
+		log.Fatal("-project and -project-id cannot be used together")
+	}
 
 	gqlclient, err := gh.GQLClient(nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	projects := getProjects(gqlclient)
-	projectId := askOneProjectId(projects)
+	var projectId string
+	if options.projectNumber != 0 {
+		projectId = resolveProjectIdByNumber(gqlclient, options.projectNumber)
+	} else {
+		projects := getProjects(gqlclient)
+		if options.projectName != "" {
+			var found bool
+			projectId, found = findProjectByName(projects, options.projectName)
+			if !found {
+				log.Fatalf("Project '%s' not found", options.projectName)
+			}
+		} else {
+			projectId = askOneProjectId(projects)
+		}
+	}
 	fields := getProjectFields(gqlclient, projectId)
 
 	var itemId string

--- a/main_test.go
+++ b/main_test.go
@@ -91,6 +91,56 @@ func TestFieldFlagsSet(t *testing.T) {
 	}
 }
 
+func TestFindProjectByName(t *testing.T) {
+	projects := []Project{
+		{Title: "Project Alpha", Id: "id-alpha", Type: "UserProject"},
+		{Title: "Project Beta", Id: "id-beta", Type: "OrganizationProject"},
+		{Title: "My Board", Id: "id-board", Type: "UserProject"},
+	}
+
+	tests := []struct {
+		name      string
+		search    string
+		wantFound bool
+		wantId    string
+	}{
+		{
+			name:      "存在するプロジェクト",
+			search:    "Project Alpha",
+			wantFound: true,
+			wantId:    "id-alpha",
+		},
+		{
+			name:      "存在しないプロジェクト",
+			search:    "NotExist",
+			wantFound: false,
+		},
+		{
+			name:      "完全一致が必要",
+			search:    "Project",
+			wantFound: false,
+		},
+		{
+			name:      "別のプロジェクト",
+			search:    "My Board",
+			wantFound: true,
+			wantId:    "id-board",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, found := findProjectByName(projects, tt.search)
+			if found != tt.wantFound {
+				t.Errorf("findProjectByName(%s) found = %v, want %v", tt.search, found, tt.wantFound)
+			}
+			if found && id != tt.wantId {
+				t.Errorf("findProjectByName(%s) Id = %s, want %s", tt.search, id, tt.wantId)
+			}
+		})
+	}
+}
+
 func TestFindOptionByName(t *testing.T) {
 	options := []Option{
 		{Id: "id1", Name: "Done"},

--- a/query.go
+++ b/query.go
@@ -60,6 +60,56 @@ func queryOrganizationProjects(gqlclient api.GQLClient, owner string) (projects 
 	return query.Organization.ProjectsV2.Nodes
 }
 
+func queryUserProjectByNumber(gqlclient api.GQLClient, login string, number int) (string, bool) {
+	var query struct {
+		User struct {
+			ProjectV2 struct {
+				Id string
+			} `graphql:"projectV2(number: $number)"`
+		} `graphql:"user(login: $login)"`
+	}
+	variables := map[string]interface{}{
+		"login":  graphql.String(login),
+		"number": graphql.Int(number),
+	}
+
+	err := gqlclient.Query("UserProjectV2", &query, variables)
+	if err != nil {
+		return "", false
+	}
+
+	if query.User.ProjectV2.Id == "" {
+		return "", false
+	}
+
+	return query.User.ProjectV2.Id, true
+}
+
+func queryOrganizationProjectByNumber(gqlclient api.GQLClient, owner string, number int) (string, bool) {
+	var query struct {
+		Organization struct {
+			ProjectV2 struct {
+				Id string
+			} `graphql:"projectV2(number: $number)"`
+		} `graphql:"organization(login: $login)"`
+	}
+	variables := map[string]interface{}{
+		"login":  graphql.String(owner),
+		"number": graphql.Int(number),
+	}
+
+	err := gqlclient.Query("OrgProjectV2", &query, variables)
+	if err != nil {
+		return "", false
+	}
+
+	if query.Organization.ProjectV2.Id == "" {
+		return "", false
+	}
+
+	return query.Organization.ProjectV2.Id, true
+}
+
 func queryProjectFieldTypes(gqlclient api.GQLClient, projectId string) []FieldType {
 	var query struct {
 		Node struct {

--- a/query_test.go
+++ b/query_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	graphql "github.com/cli/shurcooL-graphql"
 	"testing"
 )
@@ -65,6 +66,110 @@ func TestQueryOrganizationProjects(t *testing.T) {
 	if projects[0].Title != "Org Project" || projects[0].Id != "org-proj-1" {
 		t.Errorf("unexpected project: %+v", projects[0])
 	}
+}
+
+func TestQueryUserProjectByNumber(t *testing.T) {
+	t.Run("プロジェクトが見つかる", func(t *testing.T) {
+		client := &mockGQLClient{
+			queryFunc: func(name string, query interface{}, variables map[string]interface{}) error {
+				setNestedField(query, "User.ProjectV2.Id", "PVT_kwHOAxxxxx")
+				return nil
+			},
+		}
+
+		id, found := queryUserProjectByNumber(client, "testuser", 1)
+
+		assertQueryCall(t, client, 0, "UserProjectV2")
+		assertVariable(t, client.queryCalls[0].Variables, "login", graphql.String("testuser"))
+		assertVariable(t, client.queryCalls[0].Variables, "number", graphql.Int(1))
+
+		if !found {
+			t.Error("expected found to be true")
+		}
+		if id != "PVT_kwHOAxxxxx" {
+			t.Errorf("expected id PVT_kwHOAxxxxx, got %s", id)
+		}
+	})
+
+	t.Run("プロジェクトが見つからない（空ID）", func(t *testing.T) {
+		client := &mockGQLClient{
+			queryFunc: func(name string, query interface{}, variables map[string]interface{}) error {
+				return nil
+			},
+		}
+
+		_, found := queryUserProjectByNumber(client, "testuser", 999)
+
+		if found {
+			t.Error("expected found to be false")
+		}
+	})
+
+	t.Run("クエリエラー", func(t *testing.T) {
+		client := &mockGQLClient{
+			queryFunc: func(name string, query interface{}, variables map[string]interface{}) error {
+				return fmt.Errorf("query error")
+			},
+		}
+
+		_, found := queryUserProjectByNumber(client, "testuser", 1)
+
+		if found {
+			t.Error("expected found to be false")
+		}
+	})
+}
+
+func TestQueryOrganizationProjectByNumber(t *testing.T) {
+	t.Run("プロジェクトが見つかる", func(t *testing.T) {
+		client := &mockGQLClient{
+			queryFunc: func(name string, query interface{}, variables map[string]interface{}) error {
+				setNestedField(query, "Organization.ProjectV2.Id", "PVT_kwHOByyyyy")
+				return nil
+			},
+		}
+
+		id, found := queryOrganizationProjectByNumber(client, "myorg", 2)
+
+		assertQueryCall(t, client, 0, "OrgProjectV2")
+		assertVariable(t, client.queryCalls[0].Variables, "login", graphql.String("myorg"))
+		assertVariable(t, client.queryCalls[0].Variables, "number", graphql.Int(2))
+
+		if !found {
+			t.Error("expected found to be true")
+		}
+		if id != "PVT_kwHOByyyyy" {
+			t.Errorf("expected id PVT_kwHOByyyyy, got %s", id)
+		}
+	})
+
+	t.Run("プロジェクトが見つからない（空ID）", func(t *testing.T) {
+		client := &mockGQLClient{
+			queryFunc: func(name string, query interface{}, variables map[string]interface{}) error {
+				return nil
+			},
+		}
+
+		_, found := queryOrganizationProjectByNumber(client, "myorg", 999)
+
+		if found {
+			t.Error("expected found to be false")
+		}
+	})
+
+	t.Run("クエリエラー", func(t *testing.T) {
+		client := &mockGQLClient{
+			queryFunc: func(name string, query interface{}, variables map[string]interface{}) error {
+				return fmt.Errorf("query error")
+			},
+		}
+
+		_, found := queryOrganizationProjectByNumber(client, "myorg", 2)
+
+		if found {
+			t.Error("expected found to be false")
+		}
+	})
 }
 
 func TestQueryProjectFieldTypes(t *testing.T) {


### PR DESCRIPTION
## 概要

`-project`（プロジェクト名）と`-project-id`（プロジェクト番号）オプションを追加し、プロジェクト選択をCLIから非対話で指定できるようにする。

## Why

これまでプロジェクト選択は対話式プロンプトでしか行えず、`-issue`や`-field`をCLIで指定しても完全な非対話実行ができなかった。CI/スクリプトからの利用やワンライナーでの実行を可能にするため。

## How

- `query.go`: プロジェクト番号からGraphQL ID（`PVT_xxx`）を解決する`queryUserProjectByNumber`/`queryOrganizationProjectByNumber`クエリを追加
- `main.go`: `-project`（名前指定）と`-project-id`（番号指定）フラグを追加し、指定時は対話プロンプトをスキップしてプロジェクトを解決するロジックを実装
  - `-project-id`指定時はユーザープロジェクト→orgプロジェクトの順で番号からIDを解決
  - `-project`指定時はプロジェクト一覧から名前で検索
  - 両方同時指定はエラー
- `README.md`: 新オプションのドキュメントを追記

## 確認観点

- [x] `go test ./...` 全テストパス
- [x] `findProjectByName`のテスト追加（存在する/しない/部分一致不可のケース）
- [x] `queryUserProjectByNumber`のテスト追加（正常/空ID/クエリエラーのケース）
- [x] `queryOrganizationProjectByNumber`のテスト追加（正常/空ID/クエリエラーのケース）
- [x] `-project`と`-project-id`の排他チェック実装済み
- [x] `go build` ビルド成功